### PR TITLE
feature: enforceable default namespace

### DIFF
--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -113,7 +113,7 @@ spec:
           {{- end }}
           {{- else }}
           - --namespaces
-          - "{{ .Release.Name }}"          
+          - "{{ .Release.Namespace }}"          
           {{- end }}
           {{- else }}
           {{- range  .Values.namespaces }}

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -105,16 +105,9 @@ spec:
           - --label-selector={{- range $k, $v := .Values.labelSelector.matchLabels }}{{$k}}={{$v}},
           {{- end }}
           {{- end }}
-          {{- if .Values.enforceNamespaces }}
-          {{- if .Values.namespaces}}
-          {{- range  .Values.namespaces }}
+          {{- if .Values.useReleaseNamespaceOnly }}
           - --namespaces
-          - "{{ . }}"
-          {{- end }}
-          {{- else }}
-          - --namespaces
-          - "{{ .Release.Namespace }}"          
-          {{- end }}
+          - "{{ .Release.Namespace }}"
           {{- else }}
           {{- range  .Values.namespaces }}
           - --namespaces

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -105,9 +105,21 @@ spec:
           - --label-selector={{- range $k, $v := .Values.labelSelector.matchLabels }}{{$k}}={{$v}},
           {{- end }}
           {{- end }}
+          {{- if .Values.enforceNamespaces }}
+          {{- if .Values.namespaces}}
           {{- range  .Values.namespaces }}
           - --namespaces
           - "{{ . }}"
+          {{- end }}
+          {{- else }}
+          - --namespaces
+          - "{{ .Release.Name }}"          
+          {{- end }}
+          {{- else }}
+          {{- range  .Values.namespaces }}
+          - --namespaces
+          - "{{ . }}"
+          {{- end }}
           {{- end }}
           volumeMounts:
           - name: fluentconf

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -83,3 +83,7 @@ updateStrategy: {}
 #  scheduler.alpha.kubernetes.io/tolerations: '[{"key": "example", "value": "foo"}]'
 
 prometheusEnabled: false
+
+# If set to true, the log-router will only capture logs from the namespace it belongs to.
+# Otherwise, it will capture logs from all namespaces.
+useReleaseNamespaceOnly: false


### PR DESCRIPTION
As it currently stands, fluentdoperators will go through all namespaces by default.

If we have two releases on the same cluster with different namespaces, it is desirable to configure each fluentdoperator to go through its own namespace / set of namespaces.

By enforcing this behaviour, then the fluentdoperators can run against their own release namespace if no range of namespaces is passed through.